### PR TITLE
Update README.md to be less shell dependant

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ If plant uml was installed by homebrew, you can add the following code to your `
 
 ```vim
 au FileType plantuml let g:plantuml_previewer#plantuml_jar_path = get(
-    \  matchlist(system('cat `which plantuml` | grep plantuml.jar'), '\v.* (\S+plantuml\.jar).*'),
+    \  matchlist(system('grep plantuml.jar /usr/local/bin/plantuml'), '\v.* (\S+plantuml\.jar).*'),
     \  1,
     \  0
     \)


### PR DESCRIPTION
Removed the need for pipe (|), command expansion with backticks (`), and
the which Bash function.

Typically you want to stay away from using `which` in a script and
instead use something like `type -p` since it is more universal.  Since
`brew` consistently installs commands to `/usr/local/bin` we can provide
an absolute path here instead.

The `grep` command can take in a file which allows us to remove the need
to run `cat` and remove the need for a pipe.

This has the added benefit of working even if someone uses a shell other
than Bash, such as Fish.