### PR TITLE
Fix image generation when a name is defined on startuml

### DIFF
--- a/script/update-viewer.sh
+++ b/script/update-viewer.sh
@@ -11,6 +11,6 @@ image_type=$6
 timestamp=$7
 update_js_path=$8
 
-java -Dapple.awt.UIElement=true -jar "$jar_path" "$puml_src_path" -t$image_type -o "$output_dir_path"
+cat "$puml_src_path" | java -Dapple.awt.UIElement=true -jar "$jar_path" -pipe -t$image_type -o "$output_dir_path" > $output_path
 cp "$output_path" "$finial_path"
 echo "window.updateDiagramURL('$timestamp')" > "$update_js_path"


### PR DESCRIPTION
This address this issue: https://github.com/weirongxu/plantuml-previewer.vim/issues/23

According to [this post](https://forum.plantuml.net/5483/please-specify-filename-%40startuml-extension-automatically?show=5483#q5483), the output filename will be the as the startuml value, when present.

The solution is use the pipe parameter from plantuml.jar to create the output file, instead of the default behavior.

This is a workaround, feel free reject and do a proper fix.