### PR TITLE
Make the plugin work on servers/wsl/headless mode

### DIFF
--- a/script/save-as.sh
+++ b/script/save-as.sh
@@ -7,5 +7,5 @@ output_path=$4
 save_path=$5
 image_type=$6
 
-java -Dapple.awt.UIElement=true -jar "$jar_path" "$puml_src_path" -t$image_type -o "$output_dir_path"
+java -Dapple.awt.UIElement=true -Djava.awt.headless=true -jar "$jar_path" "$puml_src_path" -t$image_type -o "$output_dir_path"
 cp "$output_path" "$save_path"

--- a/script/update-viewer.sh
+++ b/script/update-viewer.sh
@@ -11,6 +11,6 @@ image_type=$6
 timestamp=$7
 update_js_path=$8
 
-java -Dapple.awt.UIElement=true -jar "$jar_path" "$puml_src_path" -t$image_type -o "$output_dir_path"
+java -Dapple.awt.UIElement=true -Djava.awt.headless=true -jar "$jar_path" "$puml_src_path" -t$image_type -o "$output_dir_path"
 cp "$output_path" "$finial_path"
 echo "window.updateDiagramURL('$timestamp')" > "$update_js_path"


### PR DESCRIPTION
Normally plantuml requires an X11 server. This is not necessary for this plugin and prevents it to work on wsl or server, even if the wsl can open a browser on the host and the server could save the image somewhere. Therefore I've added the headless mode flag to the plantuml call.